### PR TITLE
Implement DBFacade option functions

### DIFF
--- a/src/main/java/p1admin/ConnectionTest.java
+++ b/src/main/java/p1admin/ConnectionTest.java
@@ -26,8 +26,8 @@ public class ConnectionTest {
         OptionMapper om = new OptionMapper(cpds);
         om.insert(new Object[] {1, 1, "This is a question"});
 
-        om.update(new Object[] {1, "Ok now watch this!"}, new Object[] {1});
-        System.out.println(om.findById(new Object[] {1}));
+        om.update(new Object[] {1, "Ok now watch this!"}, new Object[] {1, 1});
+        System.out.println(om.findById(new Object[] {1, 1}));
 
         pm.delete(new Object[] {1});
         cpds.close();

--- a/src/main/java/p1admin/ConnectionTest.java
+++ b/src/main/java/p1admin/ConnectionTest.java
@@ -1,9 +1,12 @@
 package p1admin;
 
-import p1admin.adminDB.OptionMapper;
+import p1admin.adminDB.DBFacade;
+import p1admin.adminDB.GenericDBFacade;
 import p1admin.adminDB.PreguntaMapper;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
+import p1admin.model.Opcion;
+import p1admin.model.Pregunta;
 
 public class ConnectionTest {
 
@@ -19,17 +22,31 @@ public class ConnectionTest {
         cpds.setAcquireRetryDelay(1);
         cpds.setBreakAfterAcquireFailure(true);
 
+        GenericDBFacade<Pregunta, Opcion> facade = new DBFacade(cpds);
         PreguntaMapper pm = new PreguntaMapper(cpds);
         Object[] values = new Object[] {"¿Te gusta el pimiento?"};
         pm.insert(values);
 
-        OptionMapper om = new OptionMapper(cpds);
-        om.insert(new Object[] {1, 1, "This is a question"});
+        Pregunta p = new Pregunta();
+        p.setId(1);
+        p.setEnunciado("Te gusta el pimiento?");
 
-        om.update(new Object[] {1, "Ok now watch this!"}, new Object[] {1, 1});
-        System.out.println(om.findById(new Object[] {1, 1}));
+        Opcion op = new Opcion();
+        Opcion op1 = new Opcion();
+        op.setTexto("This is a question");
+        op1.setTexto("This is another question");
 
-        pm.delete(new Object[] {1});
+        p.addOpcion(op);
+        p.addOpcion(op1);
+
+        facade.insertAnswer(p, op);
+        facade.insertAnswer(p, op1);
+
+        op.setTexto("Booya!");
+        p.intercambiarOpciones(1,2);
+        facade.updateAnswer(p, op);
+        facade.updateAnswer(p, op1);
+
         cpds.close();
     }
 }

--- a/src/main/java/p1admin/adminDB/DBFacade.java
+++ b/src/main/java/p1admin/adminDB/DBFacade.java
@@ -18,18 +18,15 @@ import p1admin.model.Pregunta;
  * 
  */
 public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
-    // TODO Introduce los atributos que sean necesarios.
-    private DataSource ds;
-    private PreguntaMapper pm;
 
-    // TODO Si es necesario, añade el constructor que inicialice esos atributos.
+    private PreguntaMapper pm;
+    private OptionMapper oMapper;
+
     public DBFacade(DataSource ds) {
-		super();
-		this.ds = ds;
-		this.pm = new PreguntaMapper(ds);
-	}
-    
-    
+        this.pm = new PreguntaMapper(ds);
+        this.oMapper = new OptionMapper(ds);
+    }
+
     /**
      * Inserta una pregunta en la base de datos.
      *
@@ -138,8 +135,14 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void updateAnswer(Pregunta question, Opcion answer) {
         System.out.println("Actualizar opción " + answer);
-        // TODO Implementar Ergl
 
+        this.oMapper.update(new Object[] {
+            answer.getNumeroOrden(),
+            answer.getTexto()
+        }, new Object[] {
+            question.getId(),
+            answer.getNumeroOrden()
+        });
     }
 
     /**
@@ -157,7 +160,10 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void deleteAnswer(Pregunta question, Opcion answer) {
         System.out.println("Eliminar opción " + answer);
-        // TODO Implementar Ergl
+        this.oMapper.delete(new Object[] {
+            question.getId(),
+            answer.getNumeroOrden()
+        });
     }
 
     /**
@@ -176,7 +182,9 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void deleteQuestion(Pregunta question) {
         System.out.println("Eliminar pregunta " + question);
-        // TODO Implementar Ergl
+        this.pm.delete(new Object[] {
+            question.getId()
+        });
     }
 
     /**
@@ -193,6 +201,6 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void insertAnswer(Pregunta question, Opcion answer) {
         System.out.println("Insertar " + answer);
-        // TODO Implementar Ergl
+        this.oMapper.insert(answer);
     }
 }

--- a/src/main/java/p1admin/adminDB/OptionMapper.java
+++ b/src/main/java/p1admin/adminDB/OptionMapper.java
@@ -32,7 +32,10 @@ public class OptionMapper extends AbstractMapper<Opcion> {
 
     @Override
     protected String[] getKeyColumnNames() {
-        return new String[] {"answerId"};
+        return new String[] {
+            "questionId",
+            "questionOrder"
+        };
     }
 
     @Override


### PR DESCRIPTION
This pull request:

- Changes `OptionMapper.getKeyColumnNames` to return `{questionId, questionOrder}` instead of `answerId`. This makes `OptionMapper.update` much easier to work with—previously we had to supply the autoincrement key, which we couldn't get from the `Opcion` object.

- Implements `insertAnswer`, `updateAnswer`, `deleteAnswer` and `deleteQuestion` from `DBFacade`. I also changed `ConnectionTest` to explain how to use it.
