### PR TITLE
Add UI frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+database.properties
+grant.sql
+
 ### OSX ###
 .DS_Store
 .AppleDouble

--- a/database.properties
+++ b/database.properties
@@ -1,0 +1,3 @@
+db.url = jdbc:mysql://<path.to.server>/<database.name>
+db.user = <user>
+db.pass = <password>

--- a/src/main/java/p1admin/ConnectionTest.java
+++ b/src/main/java/p1admin/ConnectionTest.java
@@ -11,12 +11,12 @@ import p1admin.model.Pregunta;
 public class ConnectionTest {
 
     public static void main(String[] args) {
-
-        // Inicialización del pool de conexiones
+        DatabaseProperties props = new DatabaseProperties();
         ComboPooledDataSource cpds = new ComboPooledDataSource();
-        cpds.setJdbcUrl("jdbc:mysql://localhost:8889/abd_test");
-        cpds.setUser("abd");
-        cpds.setPassword("");
+
+        cpds.setJdbcUrl(props.getUrl());
+        cpds.setUser(props.getUser());
+        cpds.setPassword(props.getPass());
 
         cpds.setAcquireRetryAttempts(1);
         cpds.setAcquireRetryDelay(1);

--- a/src/main/java/p1admin/DatabaseProperties.java
+++ b/src/main/java/p1admin/DatabaseProperties.java
@@ -1,0 +1,45 @@
+package p1admin;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Properties;
+
+public class DatabaseProperties {
+    private final String PROPERTIES_URL = "./database.properties";
+
+    private String url;
+    private String user;
+    private String pass;
+
+    public DatabaseProperties() {
+        Properties props = getProperties();
+        this.url = props.getProperty("db.url");
+        this.user = props.getProperty("db.user");
+        this.pass = props.getProperty("db.pass");
+    }
+
+    public String getUrl() {
+        return this.url;
+    }
+
+    public String getUser() {
+        return this.user;
+    }
+
+    public String getPass() {
+        return this.pass;
+    }
+
+    private Properties getProperties() {
+        Properties props = new Properties();
+
+        try (FileInputStream in = new FileInputStream(PROPERTIES_URL)) {
+            props.load(in);
+        } catch (IOException e) {
+            System.err.println("Configuration file not found\nAborting...");
+            System.exit(2);
+        }
+
+        return props;
+    }
+}

--- a/src/main/java/p1admin/Main.java
+++ b/src/main/java/p1admin/Main.java
@@ -13,10 +13,12 @@ import p1admin.model.Pregunta;
 
 public class Main {
     public static void main(String[] args) {
+        DatabaseProperties props = new DatabaseProperties();
         ComboPooledDataSource cpds = new ComboPooledDataSource();
-        cpds.setJdbcUrl("jdbc:mysql://localhost/abd_test");
-        cpds.setUser("root");
-        cpds.setPassword("");
+
+        cpds.setJdbcUrl(props.getUrl());
+        cpds.setUser(props.getUser());
+        cpds.setPassword(props.getPass());
 
         cpds.setAcquireRetryAttempts(1);
         cpds.setAcquireRetryDelay(1);

--- a/src/main/java/p1admin/Main.java
+++ b/src/main/java/p1admin/Main.java
@@ -1,14 +1,10 @@
 package p1admin;
 
-import javax.sql.DataSource;
 import javax.swing.DefaultListModel;
 
 import com.mchange.v2.c3p0.ComboPooledDataSource;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import p1admin.adminDB.FauxDBFacade;
+import p1admin.adminDB.DBFacade;
 import p1admin.adminDB.GenericDBFacade;
 import p1admin.admincontroller.AllQuestionsController;
 import p1admin.adminview.AllQuestionsEditor;
@@ -17,7 +13,6 @@ import p1admin.model.Pregunta;
 
 public class Main {
     public static void main(String[] args) {
-        // TODO Inicializar conexión a BD, con patron Connection Pooling usando C3p0
         ComboPooledDataSource cpds = new ComboPooledDataSource();
         cpds.setJdbcUrl("jdbc:mysql://localhost/abd_test");
         cpds.setUser("root");
@@ -27,27 +22,13 @@ public class Main {
         cpds.setAcquireRetryDelay(1);
         cpds.setBreakAfterAcquireFailure(true);
 
-        DataSource ds = cpds;
-        try {
-            Connection con = ds.getConnection();
+        GenericDBFacade<Pregunta, Opcion> facade = new DBFacade(cpds);
 
-            // TODO Cambiar inicialización de fachada a BD añadiendo
-            // los parámetros que sean necesarios
+        DefaultListModel<Pregunta> model = new DefaultListModel<>();
+        AllQuestionsController controller = new AllQuestionsController(model, facade);
+        AllQuestionsEditor ed = new AllQuestionsEditor(model, controller);
 
-            GenericDBFacade<Pregunta, Opcion> facade = new FauxDBFacade();
-
-            DefaultListModel<Pregunta> model = new DefaultListModel<>();
-            AllQuestionsController controller = new AllQuestionsController(model, facade);
-            AllQuestionsEditor ed = new AllQuestionsEditor(model, controller);
-            ed.setModal(true);
-            ed.setVisible(true);
-
-        } catch (SQLException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
-
-        // TODO: Cerrar conexión
-        cpds.close();
+        ed.setModal(true);
+        ed.setVisible(true);
     }
 }

--- a/src/main/java/p1admin/adminDB/DBFacade.java
+++ b/src/main/java/p1admin/adminDB/DBFacade.java
@@ -1,6 +1,5 @@
 package p1admin.adminDB;
 
-import java.util.LinkedList;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -65,11 +64,7 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
      */
     @Override
     public List<Pregunta> getAllQuestions() {
-
-        LinkedList<Pregunta> res = new LinkedList<Pregunta>();
-        res.addAll(pm.selectAllWithOptions());
-        
-        return res;
+        return pm.selectAllWithOptions();
     }
 
     /**
@@ -89,11 +84,7 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
      */
     @Override
     public List<Pregunta> findQuestionsContaining(String text) {
-
-        LinkedList<Pregunta> res = new LinkedList<Pregunta>();
-        res.addAll(pm.selectAllWithOptions(text));
-        
-        return res;
+        return pm.selectAllWithOptions(text);
     }
 
     /**

--- a/src/main/java/p1admin/adminDB/DBFacade.java
+++ b/src/main/java/p1admin/adminDB/DBFacade.java
@@ -187,6 +187,12 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void insertAnswer(Pregunta question, Opcion answer) {
         System.out.println("Insertar " + answer);
+        // FIXME UGLY HACK!!!
+        if (question.getId() == null) {
+            List<Pregunta> possible = findQuestionsContaining(question.getEnunciado());
+            question = possible.get(possible.size() - 1);
+            answer.setPreguntaMadre(question);
+        }
         this.oMapper.insert(answer);
     }
 }

--- a/src/main/java/p1admin/adminDB/DBFacade.java
+++ b/src/main/java/p1admin/adminDB/DBFacade.java
@@ -40,14 +40,10 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
      */
     @Override
     public void insertQuestion(Pregunta question) {
-
-        if(!pm.insert(question)){
+        if (!pm.insert(question)){
             System.out.println("Problema al insertar pregunta en BD: " + question);
         }
-        
     }
-
-
 
 	/**
      * Devuelve todas las preguntas de la base de datos.
@@ -104,7 +100,6 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
      */
     @Override
     public void updateQuestion(Pregunta question) {
-
         pm.update(question);
     }
 

--- a/src/main/java/p1admin/adminDB/PreguntaMapper.java
+++ b/src/main/java/p1admin/adminDB/PreguntaMapper.java
@@ -57,7 +57,7 @@ public class PreguntaMapper extends AbstractMapper<Pregunta>{
         Object[] o = new Object[1];
         o[0] = obInsert.getEnunciado();
         
-        return !this.insert(o);
+        return this.insert(o);
     }
 
     /**

--- a/src/main/java/p1admin/adminDB/PreguntaMapper.java
+++ b/src/main/java/p1admin/adminDB/PreguntaMapper.java
@@ -41,16 +41,13 @@ public class PreguntaMapper extends AbstractMapper<Pregunta>{
 
 
     @Override
-    protected Pregunta buildObjectFromResultSet(ResultSet rs)
-            throws SQLException {
-        //TODO
+    protected Pregunta buildObjectFromResultSet(ResultSet rs) throws SQLException {
         int qId = rs.getInt(getKeyColumnNames()[0]);
         String content = rs.getString(getColumnNames()[0]);
         
         Pregunta p = new Pregunta();
         p.setId(qId);
         p.setEnunciado(content);
-        
 
         return p;
     }
@@ -73,7 +70,6 @@ public class PreguntaMapper extends AbstractMapper<Pregunta>{
 		cv[0]=question.getEnunciado();
 		kv[0]=question.getId();
 		this.update(cv, kv);
-		
 	}
 
     /**


### PR DESCRIPTION
This pull request:

- (0a485f1fd484e6f333165c73ce79d9ae80c818a1, f8b425e72ee49a0e14cd9ee3ba709158819564a6, 0a4feb97bd2bd6c897cd8eb5db9dbf45fbe915e3) Cleans up whitespace on `PreguntaMapper` and `DBFacade`

- (5064b5eabd7e5badad2ff39a852a92b8510cff87) Simplifies `selectAllWithOptions` deduplication method.

- (0e145f634ac2631f951cf7ed168ebce62a684c79) Fixes inverted logic on `PreguntaMapper`.

- (28757fcb7c6929b15dfd91e10fde4896cb1f729d) Attach the UI to `DBFacade`, modify `Main` to reflect that. __See note below__

- (255e6a26657841bc93a58c2765b51aeb3895b01d, d405f25741965377c5b48fc23d9d29f95a4c8036) Moves database configuration to a file called `database.properties`. Also creates a `DatabaseProperties` class to get the different database configuration values. Modified `Main` and `ConnectionTest` to reflect this.

#### Note

The first time we create a new `Question` with the UI, it will go and insert that question in the database. However, we don't get back the `id`that it assigned it—therefore, we will have the `id` field set to `null` until we restart the application.

This causes several, major problems:

- _We can't insert answers to questions created since the last restart_. I fixed this by checking if `question.getId` is `null`. [If it is, fetch the __last__ question from the database that has the same content](https://github.com/ergl/Cergler/blob/28757fcb7c6929b15dfd91e10fde4896cb1f729d/src/main/java/p1admin/adminDB/DBFacade.java#L190). This works, but fails if we have two questions with the same content, created at the same time, and then try to add answers to the first one (the application will add them to the latest one)

-  _We can't delete questions created since the last restart_. See above, this is __not__ fixed. Since the question doesn't have an `id`, we don't know what `question` to delete.

- _We can't edit answers in questions created since the last restart_. See above, this is __not__ fixed. Since the `id` in question is `null`, it won't find any matching `answer` in the database and fail to change it. This applies to content editing and changing the order. The UI will show the correct behaviour, but it will not be saved between restarts.

- _We can't delete answers in questions created since the last restart_. See first point, this is __not__ fixed. Although we can create answers, we can't delete them (same problem). It will be deleted from the UI however, and this allows to create a new answer, with the same order as the one that we _supposedly_ deleted, giving us an `MySQLIntegrityConstraintViolationException:  Duplicate entry ...  for key questionId`.

##### How to fix

- ~~Change `PreguntaMapper.insert(Pregunta) :  bool` so that if the given question does not contain an `id` (`id == null`), we retrieve the given question from the database, get the id from there, and set it to the given question.~~ Nope, doesn't work, as the question is passed by copy, we can't update it.

- Other ???