### PR TITLE
Fetch question id if current question id is null

### DIFF
--- a/src/main/java/p1admin/adminDB/DBFacade.java
+++ b/src/main/java/p1admin/adminDB/DBFacade.java
@@ -122,6 +122,10 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     public void updateAnswer(Pregunta question, Opcion answer) {
         System.out.println("Actualizar opción " + answer);
 
+        if (question.getId() == null) {
+            question = getLastMatching(question.getEnunciado());
+        }
+
         this.oMapper.update(new Object[] {
             answer.getNumeroOrden(),
             answer.getTexto()
@@ -146,6 +150,11 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void deleteAnswer(Pregunta question, Opcion answer) {
         System.out.println("Eliminar opción " + answer);
+
+        if (question.getId() == null) {
+            question = getLastMatching(question.getEnunciado());
+        }
+
         this.oMapper.delete(new Object[] {
             question.getId(),
             answer.getNumeroOrden()
@@ -168,6 +177,11 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void deleteQuestion(Pregunta question) {
         System.out.println("Eliminar pregunta " + question);
+
+        if (question.getId() == null) {
+            question = getLastMatching(question.getEnunciado());
+        }
+
         this.pm.delete(new Object[] {
             question.getId()
         });
@@ -187,12 +201,16 @@ public class DBFacade implements GenericDBFacade<Pregunta, Opcion> {
     @Override
     public void insertAnswer(Pregunta question, Opcion answer) {
         System.out.println("Insertar " + answer);
-        // FIXME UGLY HACK!!!
+
         if (question.getId() == null) {
-            List<Pregunta> possible = findQuestionsContaining(question.getEnunciado());
-            question = possible.get(possible.size() - 1);
-            answer.setPreguntaMadre(question);
+            answer.setPreguntaMadre(getLastMatching(question.getEnunciado()));
         }
+
         this.oMapper.insert(answer);
+    }
+
+    private Pregunta getLastMatching(String text) {
+        List<Pregunta> candidates = findQuestionsContaining(text);
+        return candidates.get(candidates.size() - 1);
     }
 }


### PR DESCRIPTION
This pull request solves mosts of the limitations in #5 

Still, we have the following problems:

- Creating two different questions with the same name, and without answers. If we add answers to the first one, we will add them to the second one instead. Then, if the user wants to add answers to the second one, it will fail with a duplicate key error.

- When deleting answers, deleting the first one (or whatever answer that isn't the last one) won't update the `questionOrder` of the rest. Therefore, trying to add new answers will fail with a duplicate key error.